### PR TITLE
remove hard coded references to S3 URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,14 @@
 
 # dependencies
 /node_modules
+package-lock.json
 
 # AWS
 amplify
 .amplifyrc
 src/aws-exports.js
+src/graphql
+.graphqlconfig.yml
 
 # testing
 /coverage

--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@ Text to audio translation using AWS AppSync, React, Amazon Polly, Amazon Transla
 
 ## Getting started
 
-1. Clone the project & change into the new directory
+0. Clone the project & change into the new directory
 
 ```sh
 git clone https://github.com/dabit3/appsync-web-translator.git
 
 cd appsync-web-translator
+```
+
+1. Install dependencies
+
+```sh
+npm install
 ```
 
 2. Initialize a new AWS Amplify project
@@ -115,7 +121,7 @@ exports.handler = (event, context, callback) => {
       else  {
         let key = uuidV4()
         const params2 = {
-          Key: key,
+          Key: 'public/' + key,
           ContentType: 'audio/mpeg',
           Body: data.AudioStream,
           ACL: 'public-read'
@@ -135,4 +141,4 @@ exports.handler = (event, context, callback) => {
 
 ```
 
-8. Add permissions to Lambda role for Rekognition as well as S3
+8. Add permissions to Lambda role for Polly, Translate as well as S3

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
 import './App.css';
 import { css } from 'glamor'
-import { API, graphqlOperation } from 'aws-amplify'
+import { API, Storage, graphqlOperation } from 'aws-amplify'
 import { withAuthenticator } from 'aws-amplify-react'
 import spinner from './spinner.png';
-
-const url = "https://s3.us-east-2.amazonaws.com/amplifytranslators3bucket/19b3b75b-caa7-4e3f-bedc-57dae4ab70be";
 
 const buttons = [
   'French',
@@ -28,14 +26,13 @@ const GetAudioQuery = `
     }
   }
 `
-
 class App extends Component {
   state = {
     play: false, language: 'French', audio: {}, text: '', audioReady: false, fetching: false
   };
   
   componentDidMount() {
-    this.audio = new Audio(url);
+    this.audio = new Audio();
     this.audio.addEventListener("ended", () => {
       this.setState({ play: false })
     });
@@ -60,7 +57,8 @@ class App extends Component {
     try {
       const audioData = await API.graphql(graphqlOperation(GetAudioQuery, data))
       const key = audioData.data.getTranslatedSentence.sentence
-      const url = `https://s3.us-east-2.amazonaws.com/amplifytranslators3bucket/${key}`
+      const url = await Storage.get(key);
+      console.log('The URL is', url);
       this.audio = new Audio(url)
       this.setState({
         audioReady: true,


### PR DESCRIPTION
I removed the hard coded reference to the S3 URL.  

- lambda function now prepends 'public/' to key name (to comply with amplify's Storage service)
- App.js uses `Storage.get` to retrieve a signed URL

I modified the list of policies to add to the Lambda role.